### PR TITLE
Quicklogging pre-existing sources

### DIFF
--- a/commands/log/qlog.js
+++ b/commands/log/qlog.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
+const User = require('../../models/User');
 const Source = require('../../models/Source');
 
 module.exports = {
@@ -6,7 +7,29 @@ module.exports = {
         .setName('qlog')
         .setDescription('Quick log pre-existing source')
         .addStringOption(option =>
-            option.setName('query')
-                .setDescription('Phrase to search for')
-                .setAutoComplete(true)),
-}
+            option.setName('source')
+                .setDescription('Source to log')
+                .setAutocomplete(true)
+                .setRequired(true))
+        .addIntegerOption(option =>
+            option.setName('time')
+                .setDescription('Time to log')
+                .setRequired(true)),
+    async autocomplete(interaction) {
+        const focusedValue = interaction.options.getFocused();
+        const [user, created] = await User.findOrCreate({ where: { userId: interaction.user.id}});
+        const sources = await Source.findAll({ where: { userId: interaction.user.id, status: "In Progress", oneTime: false}});
+        const choices = [];
+        sources.forEach(source => {
+            console.log(source.sourceName);
+            choices.push(source.sourceName);
+        })
+        const filtered = choices.filter(choice => choice.startsWith(focusedValue));
+        await interaction.respond(
+            filtered.map(choice => ({ name: choice, value: choice}))
+        );
+    },
+    async execute(interaction) {
+        
+    },
+};

--- a/commands/log/qlog.js
+++ b/commands/log/qlog.js
@@ -25,6 +25,10 @@ module.exports = {
         await interaction.respond(filtered);
     },
     async execute(interaction) {
-        
+        const sourceId = interaction.options.getString('source');
+        const duration = interaction.options.getInteger('duration');
+        console.log(duration);
+
+        await interaction.reply( { content: `Source id chosen: ${sourceId}, duration: ${duration}` });
     },
 };

--- a/commands/log/qlog.js
+++ b/commands/log/qlog.js
@@ -1,5 +1,4 @@
 const { SlashCommandBuilder } = require('discord.js');
-const User = require('../../models/User');
 const Source = require('../../models/Source');
 
 module.exports = {
@@ -12,21 +11,18 @@ module.exports = {
                 .setAutocomplete(true)
                 .setRequired(true))
         .addIntegerOption(option =>
-            option.setName('time')
-                .setDescription('Time to log')
+            option.setName('duration')
+                .setDescription('Time to log (minutes)')
                 .setRequired(true)),
     async autocomplete(interaction) {
         const focusedValue = interaction.options.getFocused();
         const sources = await Source.findAll({ where: { userId: interaction.user.id, status: "In Progress", oneTime: false}});
         const choices = [];
         sources.forEach(source => {
-            console.log(source.sourceName);
-            choices.push(source.sourceName);
+            choices.push({ name: source.sourceName, value: source.sourceId.toString() });
         })
-        const filtered = choices.filter(choice => choice.startsWith(focusedValue));
-        await interaction.respond(
-            filtered.map(choice => ({ name: choice, value: choice}))
-        );
+        const filtered = choices.filter(choice => choice.name.startsWith(focusedValue));
+        await interaction.respond(filtered);
     },
     async execute(interaction) {
         

--- a/commands/log/qlog.js
+++ b/commands/log/qlog.js
@@ -17,7 +17,6 @@ module.exports = {
                 .setRequired(true)),
     async autocomplete(interaction) {
         const focusedValue = interaction.options.getFocused();
-        const [user, created] = await User.findOrCreate({ where: { userId: interaction.user.id}});
         const sources = await Source.findAll({ where: { userId: interaction.user.id, status: "In Progress", oneTime: false}});
         const choices = [];
         sources.forEach(source => {

--- a/commands/log/qlog.js
+++ b/commands/log/qlog.js
@@ -1,0 +1,12 @@
+const { SlashCommandBuilder } = require('discord.js');
+const Source = require('../../models/Source');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('qlog')
+        .setDescription('Quick log pre-existing source')
+        .addStringOption(option =>
+            option.setName('query')
+                .setDescription('Phrase to search for')
+                .setAutoComplete(true)),
+}

--- a/commands/log/qlog.js
+++ b/commands/log/qlog.js
@@ -27,7 +27,6 @@ module.exports = {
     async execute(interaction) {
         const sourceId = interaction.options.getString('source');
         const duration = interaction.options.getInteger('duration');
-        console.log(duration);
 
         await interaction.reply( { content: `Source id chosen: ${sourceId}, duration: ${duration}` });
     },

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -3,7 +3,20 @@ const { Events } = require('discord.js');
 module.exports = {
 	name: Events.InteractionCreate,
 	async execute(interaction) {
-		if (!interaction.isChatInputCommand()) return;
+		if (interaction.isAutocomplete()) {
+			const command = interaction.client.commands.get(interaction.commandName);
+
+			if(!command) {
+				console.error(`No command matching ${interaction.commandName} was found.`);
+				return;
+			}
+
+			try {
+				await command.autocomplete(interaction);
+			} catch (error) {
+				console.error(error);
+			}
+		} 
 
 		const command = interaction.client.commands.get(interaction.commandName);
 

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -3,33 +3,23 @@ const { Events } = require('discord.js');
 module.exports = {
 	name: Events.InteractionCreate,
 	async execute(interaction) {
-		if (interaction.isAutocomplete()) {
-			const command = interaction.client.commands.get(interaction.commandName);
+        const command = interaction.client.commands.get(interaction.commandName);
 
-			if(!command) {
-				console.error(`No command matching ${interaction.commandName} was found.`);
-				return;
-			}
+        if (!command) {
+            console.error(`No command matching ${interaction.commandName} was found.`);
+            return;
+        }
 
-			try {
-				await command.autocomplete(interaction);
-			} catch (error) {
-				console.error(error);
-			}
-		} 
+        try {
+            if (interaction.isAutocomplete()) {
+                await command.autocomplete(interaction);
+            }
+            else if (interaction.isChatInputCommand()) {
+                await command.execute(interaction);
+            }
+        } catch (error) {
+            console.error(error);
+        }
 
-		const command = interaction.client.commands.get(interaction.commandName);
-
-		if (!command) {
-			console.error(`No command matching ${interaction.commandName} was found.`);
-			return;
-		}
-
-		try {
-			await command.execute(interaction);
-		} catch (error) {
-			console.error(`Error executing ${interaction.commandName}`);
-			console.error(error);
-		}
 	},
 };


### PR DESCRIPTION
/qlog allows user to fill out the fields required to make a log without having to mess around with the menus in the regular /log command. This is only for pre-existing sources, something similar can be made for one-time sources.

Closes #3